### PR TITLE
Remove "version" from Docker Compose file.

### DIFF
--- a/course_content/0.0-Introduction and Setup/0.1-Setup Steps.md
+++ b/course_content/0.0-Introduction and Setup/0.1-Setup Steps.md
@@ -14,8 +14,6 @@
 - Write the following data into a file named `compose.yml` Keep this file outside of the `detection-with-sigma` folder as it will contain plaintext passwords that we do not want to risk being in our public GitHub repo. In case you ignore this instruction, I have added compose.yml to the git ignore file.
 
 ```yaml
-version: "3.8"
-
 services:
     sigma-splunk:
         image: splunk/splunk:latest


### PR DESCRIPTION
Remove "version" attribute from Docker Compose file because it is obsolete.

References:
- https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md#version-top-level-element-obsolete
- https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete