### PR TITLE
Include SPL abbreviation expansion.

### DIFF
--- a/course_content/1.0-Understanding Sigma Rules/1.0-Understanding Sigma Rules.md
+++ b/course_content/1.0-Understanding Sigma Rules/1.0-Understanding Sigma Rules.md
@@ -43,7 +43,7 @@ falsepositives:
 level: low
 ```
 
-Sigma rules are human-readable. While SPL is a powerful query language, it can often be difficult to understand what is going on. Sigma attempts to use descriptive `key:value` pairs that give context to an analyst when they are ready to investigate. I will break down the components of this rule and perhaps give some insight in how we can build a backend to interpret this rule and convert it to SPL.
+Sigma rules are human-readable. While the Splunk Search Processing Language (SPL) is a powerful query language, it can often be difficult to understand what is going on. Sigma attempts to use descriptive `key:value` pairs that give context to an analyst when they are ready to investigate. I will break down the components of this rule and perhaps give some insight in how we can build a backend to interpret this rule and convert it to SPL.
 
 Starting from the top we have a `title` and an `id`. These are unique fields for each rule and provide an easy way to distinguish one rule from another while bulk-importing and parsing rules. The title is best for humans, while the id field, a [universally unique identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier), is best for machines. Next we have the `related` field. This indicates that there are two other rules in the repo that share some characteristics with this rule. In this case, both of those rules share the same detection logic but are intended for a different log source. We will discuss log sources shortly.
 


### PR DESCRIPTION
The abbreviation "SPL" has not been expanded yet. Although it is obvious to students with experience in Splunk, the full form should be referenced once when it's first used so that less experienced users don't feel lost.

References: 
- https://docs.splunk.com/Splexicon:SPL